### PR TITLE
Fix tooltip blinking when mouse is moved over it

### DIFF
--- a/src/interact.js
+++ b/src/interact.js
@@ -195,7 +195,8 @@
                 .css({
                     'width': this.width,
                     'height': this.height,
-                    'visibility': 'visible'
+                    'visibility': 'visible',
+                    'pointer-events': 'none'
                 });
             if (this.hidden) {
                 this.hidden = false;


### PR DESCRIPTION
When a tooltip is displayed above the mouse pointer for sample, and le mouse moves up :

'mouseleave' is called since the tooltip caught the event
tooltip is hidden
'mouseenter' is called since the canva gets back the event
tooltip is placed above the mouse pointer