### PR TITLE
Fix for line charts with a data gap at the beginning

### DIFF
--- a/src/chart-line.js
+++ b/src/chart-line.js
@@ -246,8 +246,8 @@
                             path = [];
                             paths.push(path);
                         }
-                        vertices.push(null);
                     }
+                    vertices.push(null);
                 } else {
                     if (y < this.miny) {
                         y = this.miny;


### PR DESCRIPTION
When the values array starts with one or more null values, incorrect spot got highlighted on the chart when it was moused over.