### PR TITLE
Allow min & max values to be set for bullet charts

### DIFF
--- a/src/chart-bullet.js
+++ b/src/chart-bullet.js
@@ -14,8 +14,8 @@
             vals = values.slice();
             vals[0] = vals[0] === null ? vals[2] : vals[0];
             vals[1] = values[1] === null ? vals[2] : vals[1];
-            min = Math.min.apply(Math, values);
-            max = Math.max.apply(Math, values);
+            min = options.get('chartRangeMin') === undefined ? Math.min.apply(Math, values) : options.get('chartRangeMin');
+            max = options.get('chartRangeMax') === undefined ? Math.max.apply(Math, values) : options.get('chartRangeMax');
             if (options.get('base') === undefined) {
                 min = min < 0 ? min : 0;
             } else {


### PR DESCRIPTION
Updated bullet chart so a min and max value can be specified. This
provides the ability for a series of bullet charts to be visually
compared to one another.